### PR TITLE
fix trigger to account for different formatting on some upstream mirrors

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,7 +29,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`msedge_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1)
+          EXT_RELEASE=$(curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1 | sed 's|.*stable_||' | sed 's|_amd64.*||')
           echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^msedge_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   apt-get update && \
   echo "**** install edge ****" && \
   if [ -z ${EDGE_VERSION+x} ]; then \
-    EDGE_VERSION=$(curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1); \
+    EDGE_VERSION=$(curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1 | sed 's|.*stable_||' | sed 's|_amd64.*||'); \
   fi && \
   curl -o \
     /tmp/edge.deb -L \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1 ''',
+            script: ''' curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href="microsoft-edge-stable_|_amd64.deb")' '/href=/ {print $2}' | sort --version-sort | tail -1 | sed 's|.*stable_||' | sed 's|_amd64.*||' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-msedge
 external_type: na
-custom_version_command: "curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href=\"microsoft-edge-stable_|_amd64.deb\")' '/href=/ {print $2}' | sort --version-sort | tail -1" 
+custom_version_command: "curl -sL https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/ | awk -F'(<a href=\"microsoft-edge-stable_|_amd64.deb\")' '/href=/ {print $2}' | sort --version-sort | tail -1 | sed 's|.*stable_||' | sed 's|_amd64.*||'"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
Some mirrors return a page with slightly different html formatting, resulting in the version output of `>microsoft-edge-stable_151.0.4129.59-1_amd64.deb</a>                                                     31-Jul-2026 20:29  191.5 MB`, which results in a failed build. I confirmed the result locally, which happens intermittently.

This PR accounts for the modified formatting so the version is retrieved correctly every time.